### PR TITLE
Override getter

### DIFF
--- a/src/FedEx/AbstractComplexType.php
+++ b/src/FedEx/AbstractComplexType.php
@@ -47,6 +47,16 @@ abstract class AbstractComplexType
         $this->_values[$name] = $value;
     }
 
+
+    /**
+     * __get implementation
+     *
+     * @param string $name
+     */
+    public function __get($name) {
+        return $this->_values[$name];
+    }
+
     /**
      * Recursive algorthim to convert complex types to an array
      *


### PR DESCRIPTION
Overriding getter to use the key/value store in the parent class